### PR TITLE
Faster defer-in-loop check

### DIFF
--- a/pkg/analyzer/defer_in_loop_test.go
+++ b/pkg/analyzer/defer_in_loop_test.go
@@ -13,5 +13,5 @@ func TestDeferInLoop(t *testing.T) {
 	wd, err := os.Getwd()
 	require.Nil(t, err)
 	testdata := filepath.Join(wd, "testdata")
-	analysistest.Run(t, testdata, getDeferInloopAnalyzer(), "defer_in_loop")
+	analysistest.Run(t, testdata, getDeferInLoopAnalyzer(), "defer_in_loop")
 }


### PR DESCRIPTION
with -benchtime 10s

Old:
BenchmarkDeferInLoop
BenchmarkDeferInLoop-8    	      13	1121483914 ns/op

New:
BenchmarkDeferInLoop2
BenchmarkDeferInLoop2-8   	      12	 849916913 ns/op