### PR TITLE
Ignore references of pointer dereferenced fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/observeinc/ogl
 go 1.15
 
 require (
-	github.com/davecgh/go-spew v1.1.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/tools v0.1.4
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/observeinc/ogl
 go 1.15
 
 require (
+	github.com/davecgh/go-spew v1.1.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/tools v0.1.4
 )

--- a/pkg/analyzer/range_var_ref.go
+++ b/pkg/analyzer/range_var_ref.go
@@ -4,21 +4,23 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"go/types"
 
+	"github.com/davecgh/go-spew/spew"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
 )
 
 const (
-	expectedMaxNesting = 5
+	expectedMaxLoopNesting = 5
 )
 
 func init() {
 	registerAnalyzer(getRangeVarRefAnalyzer())
 }
 
-// getRangeVarRefAnalyzer builds and returns an Analyzer for the defer-in-loop check.
+// getRangeVarRefAnalyzer builds and returns an Analyzer for the range-variable-reference check.
 func getRangeVarRefAnalyzer() *analysis.Analyzer {
 	return &analysis.Analyzer{
 		Name:     "rangeVarRef",
@@ -28,13 +30,26 @@ func getRangeVarRefAnalyzer() *analysis.Analyzer {
 	}
 }
 
-// checkRangeVarRef checks if a defer statement exists anywhere in a loop and flags it as an issue.
+// checkRangeVarRef checks if a range variable's reference is taken.
 func checkRangeVarRef(pass *analysis.Pass) (interface{}, error) {
 	type rangeVar struct {
 		name     string
 		scopeEnd token.Pos
 	}
-	rangeVars := make([]rangeVar, 0, expectedMaxNesting)
+	rangeVars := make([]rangeVar, 0, expectedMaxLoopNesting)
+
+	checkIfRangeVar := func(id *ast.Ident, pos token.Pos) {
+		for i := len(rangeVars) - 1; i >= 0; i-- {
+			r := rangeVars[i]
+			if id.Name == r.name && pos < r.scopeEnd {
+				pass.Reportf(pos,
+					"taking reference of range variable %s or its field",
+					id.Name)
+				break
+			}
+		}
+	}
+
 	visitor := func(node ast.Node) {
 		// cleanup rangeVars that node is out of bounds of
 		for i, r := range rangeVars {
@@ -55,25 +70,25 @@ func checkRangeVarRef(pass *analysis.Pass) (interface{}, error) {
 			if s.Op != token.AND {
 				return
 			}
-			var id *ast.Ident
-			switch i := s.X.(type) {
-			case *ast.Ident:
-				id = i
-			case *ast.SelectorExpr:
-				id, _ = i.X.(*ast.Ident)
-			}
-			if id == nil {
-				return
-			}
 
-			for _, r := range rangeVars {
-				if id.Name == r.name && s.Pos() < r.scopeEnd {
-					pass.Reportf(s.Pos(),
-						"taking reference of range variable %s or its field",
-						id.Name)
-					break
+			a := s.X
+			for {
+				switch id := a.(type) {
+				case *ast.Ident:
+					checkIfRangeVar(id, s.Pos())
+					return
+				case *ast.SelectorExpr:
+					if t, ok := pass.TypesInfo.Types[id.X]; ok {
+						if _, isPointer := t.Type.(*types.Pointer); isPointer {
+							return
+						}
+					}
+					a = id.X
+				default:
+					panic(fmt.Sprintf("Unknown expr type: %s", spew.Sdump(id)))
 				}
 			}
+
 		default:
 			// this shouldn't happen, the filter below shouldn't let this happen
 			panic(fmt.Sprintf("Unexpected statement of type %T received", s))

--- a/pkg/analyzer/range_var_ref.go
+++ b/pkg/analyzer/range_var_ref.go
@@ -6,14 +6,15 @@ import (
 	"go/token"
 	"go/types"
 
-	"github.com/davecgh/go-spew/spew"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
 )
 
 const (
-	expectedMaxLoopNesting = 5
+	// max number of range variables we expect. This is just for preallocating memory.
+	// 2 range vars per loop * 5 levels of nesting should be good enough for real world code.
+	expectedMaxRangeVars = 5
 )
 
 func init() {
@@ -33,62 +34,95 @@ func getRangeVarRefAnalyzer() *analysis.Analyzer {
 // checkRangeVarRef checks if a range variable's reference is taken.
 func checkRangeVarRef(pass *analysis.Pass) (interface{}, error) {
 	type rangeVar struct {
-		name     string
-		scopeEnd token.Pos
+		name       string
+		scopeStart token.Pos
+		scopeEnd   token.Pos
 	}
-	rangeVars := make([]rangeVar, 0, expectedMaxLoopNesting)
+	rangeVars := make([]rangeVar, 0, expectedMaxRangeVars)
 
-	checkIfRangeVar := func(id *ast.Ident, pos token.Pos) {
-		for i := len(rangeVars) - 1; i >= 0; i-- {
-			r := rangeVars[i]
-			if id.Name == r.name && pos < r.scopeEnd {
-				pass.Reportf(pos,
-					"taking reference of range variable %s or its field",
-					id.Name)
-				break
+	check := func(a ast.Expr, pos token.Pos, reporter func(id *ast.Ident)) {
+		for {
+			switch id := a.(type) {
+			case *ast.Ident:
+				for i := len(rangeVars) - 1; i >= 0; i-- {
+					r := rangeVars[i]
+					if id.Name == r.name && pos > r.scopeStart && pos < r.scopeEnd {
+						reporter(id)
+						break
+					}
+				}
+				return
+			case *ast.SelectorExpr:
+				if t, ok := pass.TypesInfo.Types[id.X]; ok {
+					if _, isPointer := t.Type.(*types.Pointer); isPointer {
+						return
+					}
+				}
+				a = id.X
+			case *ast.ParenExpr:
+				a = id.X
+			case *ast.IndexExpr:
+				// skip, can assign to or take reference of items in nested
+				// containers via range variables.
+				return
+			case *ast.StarExpr:
+				// skip: a valid star expression obviously has a pointer.
+				return
+			default:
+				panic(fmt.Sprintf("Unknown expr type: %T", id))
 			}
 		}
 	}
-
 	visitor := func(node ast.Node) {
 		// cleanup rangeVars that node is out of bounds of
-		for i, r := range rangeVars {
-			if r.scopeEnd < node.Pos() {
-				rangeVars = rangeVars[:i]
-				break
+		for i := 0; i < len(rangeVars); i++ {
+			p := node.Pos()
+			if p < rangeVars[i].scopeStart || p > rangeVars[i].scopeEnd {
+				if i == len(rangeVars)-1 {
+					rangeVars = rangeVars[:i]
+				} else {
+					n := len(rangeVars) - 1
+					rangeVars[i] = rangeVars[n]
+					rangeVars = rangeVars[:n]
+					i--
+				}
 			}
 		}
 		switch s := node.(type) {
 		case *ast.RangeStmt:
 			if key, ok := s.Key.(*ast.Ident); ok && key.Name != "_" {
-				rangeVars = append(rangeVars, rangeVar{key.Name, s.End()})
+				rangeVars = append(rangeVars, rangeVar{key.Name, s.Pos(), s.End()})
 			}
 			if val, ok := s.Value.(*ast.Ident); ok && val.Name != "_" {
-				rangeVars = append(rangeVars, rangeVar{val.Name, s.End()})
+				rangeVars = append(rangeVars, rangeVar{val.Name, s.Pos(), s.End()})
 			}
 		case *ast.UnaryExpr:
 			if s.Op != token.AND {
 				return
 			}
-
-			a := s.X
-			for {
-				switch id := a.(type) {
-				case *ast.Ident:
-					checkIfRangeVar(id, s.Pos())
-					return
-				case *ast.SelectorExpr:
-					if t, ok := pass.TypesInfo.Types[id.X]; ok {
-						if _, isPointer := t.Type.(*types.Pointer); isPointer {
-							return
-						}
-					}
-					a = id.X
-				default:
-					panic(fmt.Sprintf("Unknown expr type: %s", spew.Sdump(id)))
-				}
+			if _, isComposite := s.X.(*ast.CompositeLit); isComposite {
+				// address of a literal, e.g. &myStruct{}
+				return
 			}
-
+			check(s.X, s.Pos(), func(id *ast.Ident) {
+				pass.Reportf(s.Pos(),
+					"taking reference of range variable %s or its field",
+					id.Name)
+			})
+		case *ast.IncDecStmt:
+			check(s.X, s.Pos(), func(id *ast.Ident) {
+				pass.Reportf(s.Pos(),
+					"modifying range variable %s or its field",
+					id.Name)
+			})
+		case *ast.AssignStmt:
+			for i := 0; i < len(s.Lhs); i++ {
+				check(s.Lhs[i], s.Pos(), func(id *ast.Ident) {
+					pass.Reportf(s.Pos(),
+						"modifying range variable %s or its field",
+						id.Name)
+				})
+			}
 		default:
 			// this shouldn't happen, the filter below shouldn't let this happen
 			panic(fmt.Sprintf("Unexpected statement of type %T received", s))
@@ -99,6 +133,8 @@ func checkRangeVarRef(pass *analysis.Pass) (interface{}, error) {
 	nodeFilter := []ast.Node{
 		(*ast.RangeStmt)(nil),
 		(*ast.UnaryExpr)(nil),
+		(*ast.IncDecStmt)(nil),
+		(*ast.AssignStmt)(nil),
 	}
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	insp.Preorder(nodeFilter, visitor)

--- a/pkg/analyzer/range_var_ref_test.go
+++ b/pkg/analyzer/range_var_ref_test.go
@@ -13,5 +13,5 @@ func TestRangeValRef(t *testing.T) {
 	wd, err := os.Getwd()
 	require.Nil(t, err)
 	testdata := filepath.Join(wd, "testdata")
-	analysistest.Run(t, testdata, getRangeVarRefAnalyzer(), "range_val_ref")
+	analysistest.Run(t, testdata, getRangeVarRefAnalyzer(), "range_var_ref")
 }

--- a/pkg/analyzer/testdata/src/range_val_ref/1.go
+++ b/pkg/analyzer/testdata/src/range_val_ref/1.go
@@ -1,16 +1,24 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
+
+type otherStruct struct {
+	b int
+}
 
 type myStruct struct {
 	f int
+	o *otherStruct
 }
 
-func main() {
-	lst := []myStruct{{1}, {2}, {3}}
+func lists() {
+	lst := []myStruct{}
 	for _, l := range lst {
 		fmt.Println("addr: %v", &l)   // want "taking reference of range variable l or its field"
-		fmt.Println("addr: %v", &l.f) // want "taking reference of range variable l or its field"
+		fmt.Println("addr: %v", &l.o) // want "taking reference of range variable l or its field"
 		for _, m := range lst {
 			fmt.Println("addr: %v", &m)   // want "taking reference of range variable m or its field"
 			fmt.Println("addr: %v", &m.f) // want "taking reference of range variable m or its field"
@@ -55,7 +63,29 @@ func main() {
 		fmt.Println("addr: %v", &l.f) // want "taking reference of range variable l or its field"
 	}
 
-	mp := map[int]int{}
+	for i, l := range os.Environ() {
+		fmt.Printf("addr: %v", &i) // want "taking reference of range variable i or its field"
+		fmt.Printf("addr: %v", &l) // want "taking reference of range variable l or its field"
+	}
+
+	for i, l := range os.Args {
+		fmt.Printf("addr: %v", &i) // want "taking reference of range variable i or its field"
+		fmt.Printf("addr: %v", &l) // want "taking reference of range variable l or its field"
+	}
+
+	for i, l := range []myStruct{} {
+		fmt.Printf("addr: %v", &i) // want "taking reference of range variable i or its field"
+		fmt.Printf("addr: %v", &l) // want "taking reference of range variable l or its field"
+	}
+
+	for i, l := range []*myStruct{} {
+		fmt.Printf("addr: %v", &i) // want "taking reference of range variable i or its field"
+		fmt.Printf("addr: %v", &l) // want "taking reference of range variable l or its field"
+	}
+}
+
+func maps() {
+	mp := map[myStruct]myStruct{}
 	for k1, v1 := range mp {
 		fmt.Println("addr: %v", &k1) // want "taking reference of range variable k1 or its field"
 		fmt.Println("addr: %v", &v1) // want "taking reference of range variable v1 or its field"
@@ -65,5 +95,74 @@ func main() {
 			fmt.Println("addr: %v", &k2) // want "taking reference of range variable k2 or its field"
 			fmt.Println("addr: %v", &v2) // want "taking reference of range variable v2 or its field"
 		}
+	}
+}
+
+func retListPtr() []*myStruct {
+	return nil
+}
+
+func pointers() {
+	lst := []myStruct{}
+	for i, l := range lst {
+		fmt.Printf("addr: %v", &i)     // want "taking reference of range variable i or its field"
+		fmt.Printf("addr: %v", &l)     // want "taking reference of range variable l or its field"
+		fmt.Printf("addr: %v", &l.o)   // want "taking reference of range variable l or its field"
+		fmt.Printf("addr: %v", &l.o.b) // This is ok. `o` is a pointer, so &l.o.f is same as &lst[i].o.f
+	}
+
+	plst := []*myStruct{}
+	for i, l := range plst {
+		fmt.Printf("addr: %v", &i)     // want "taking reference of range variable i or its field"
+		fmt.Printf("addr: %v", &l)     // want "taking reference of range variable l or its field"
+		fmt.Printf("addr: %v", &l.o)   // This is ok. `l` is a pointer, so &l.o is same as &lst[i].o
+		fmt.Printf("addr: %v", &l.o.b) // This is ok. `l` is a pointer, so &l.o.f is same as &lst[i].o.f
+	}
+
+	for i, l := range retListPtr() {
+		fmt.Printf("addr: %v", &i)     // want "taking reference of range variable i or its field"
+		fmt.Printf("addr: %v", &l)     // want "taking reference of range variable l or its field"
+		fmt.Printf("addr: %v", &l.o)   // This is ok. `l` is a pointer, so &l.o is same as &lst[i].o
+		fmt.Printf("addr: %v", &l.o.b) // This is ok. `l` is a pointer, so &l.o.f is same as &lst[i].o.f
+	}
+
+	mp1 := map[myStruct]myStruct{}
+	for k1, v1 := range mp1 {
+		fmt.Println("addr: %v", &k1)     // want "taking reference of range variable k1 or its field"
+		fmt.Println("addr: %v", &k1.o)   // want "taking reference of range variable k1 or its field"
+		fmt.Println("addr: %v", &k1.o.b) // This is ok. `o` is a pointer
+		fmt.Println("addr: %v", &v1)     // want "taking reference of range variable v1 or its field"
+		fmt.Println("addr: %v", &v1.o)   // want "taking reference of range variable v1 or its field"
+		fmt.Println("addr: %v", &v1.o.b) // This is ok. `o` is a pointer
+	}
+
+	mp2 := map[myStruct]*myStruct{}
+	for k1, v1 := range mp2 {
+		fmt.Println("addr: %v", &k1)     // want "taking reference of range variable k1 or its field"
+		fmt.Println("addr: %v", &k1.o)   // want "taking reference of range variable k1 or its field"
+		fmt.Println("addr: %v", &k1.o.b) // This is ok. `o` is a pointer
+		fmt.Println("addr: %v", &v1)     // want "taking reference of range variable v1 or its field"
+		fmt.Println("addr: %v", &v1.o)   // This is ok. `v1` is a pointer
+		fmt.Println("addr: %v", &v1.o.b) // This is ok. `v1` is a pointer
+	}
+
+	mp3 := map[*myStruct]myStruct{}
+	for k1, v1 := range mp3 {
+		fmt.Println("addr: %v", &k1)     // want "taking reference of range variable k1 or its field"
+		fmt.Println("addr: %v", &k1.o)   // This is ok. `k1` is a pointer
+		fmt.Println("addr: %v", &k1.o.b) // This is ok. `k1` is a pointer
+		fmt.Println("addr: %v", &v1)     // want "taking reference of range variable v1 or its field"
+		fmt.Println("addr: %v", &v1.o)   // want "taking reference of range variable v1 or its field"
+		fmt.Println("addr: %v", &v1.o.b) // This is ok. `o` is a pointer
+	}
+
+	mp4 := map[*myStruct]*myStruct{}
+	for k1, v1 := range mp4 {
+		fmt.Println("addr: %v", &k1)     // want "taking reference of range variable k1 or its field"
+		fmt.Println("addr: %v", &k1.o)   // This is ok. `k1` is a pointer
+		fmt.Println("addr: %v", &k1.o.b) // This is ok. `k1` is a pointer
+		fmt.Println("addr: %v", &v1)     // want "taking reference of range variable v1 or its field"
+		fmt.Println("addr: %v", &v1.o)   // This is ok. `v1` is a pointer
+		fmt.Println("addr: %v", &v1.o.b) // This is ok. `v1` is a pointer
 	}
 }

--- a/pkg/analyzer/testdata/src/range_var_ref/assign.go
+++ b/pkg/analyzer/testdata/src/range_var_ref/assign.go
@@ -1,0 +1,46 @@
+package main
+
+func assignLists() {
+	lst := []myStruct{}
+	for i, l := range lst {
+		i = 10         // want "modifying range variable i or its field"
+		l = myStruct{} // want "modifying range variable l or its field"
+		l.f = 10       // want "modifying range variable l or its field"
+		l.o.b = 10     // This is ok. `o` is a pointer, so l.o.b is same as lst[i].o.b
+		_, _ = i, l
+	}
+}
+
+func assignMaps() {
+	mp := map[myStruct]myStruct{}
+	for k, v := range mp {
+		k = myStruct{} // want "modifying range variable k or its field"
+		k.f = 10       // want "modifying range variable k or its field"
+		k.o.b = 10     // This is ok. `o` is a pointer, so l.o.b is same as lst[i].o.b
+		v = myStruct{} // want "modifying range variable v or its field"
+		v.f = 10       // want "modifying range variable v or its field"
+		v.o.b = 10     // This is ok. `o` is a pointer, so l.o.b is same as lst[i].o.b
+		_, _ = k, v
+	}
+}
+
+func assignPointers() {
+	lst := []*myStruct{}
+	for i, l := range lst {
+		i = 10          // want "modifying range variable i or its field"
+		l = &myStruct{} // want "modifying range variable l or its field"
+		l.f = 10        // This is ok. `l` is a pointer, so l.o.b is same as lst[i].o.b
+		l.o.b = 10      // This is ok. `l` is a pointer, so l.o.b is same as lst[i].o.b
+		_, _ = i, l
+	}
+	mp := map[*myStruct]*myStruct{}
+	for k, v := range mp {
+		k = &myStruct{} // want "modifying range variable k or its field"
+		k.f = 10        // This is ok. `k` is a pointer, so l.o.b is same as lst[i].o.b
+		k.o.b = 10      // This is ok. `k` is a pointer, so l.o.b is same as lst[i].o.b
+		v = &myStruct{} // want "modifying range variable v or its field"
+		v.f = 10        // This is ok. `v` is a pointer, so l.o.b is same as lst[i].o.b
+		v.o.b = 10      // This is ok. `v` is a pointer, so l.o.b is same as lst[i].o.b
+		_, _ = k, v
+	}
+}

--- a/pkg/analyzer/testdata/src/range_var_ref/ref.go
+++ b/pkg/analyzer/testdata/src/range_var_ref/ref.go
@@ -17,6 +17,7 @@ type myStruct struct {
 func lists() {
 	lst := []myStruct{}
 	for _, l := range lst {
+		_ = l
 		fmt.Println("addr: %v", &l)   // want "taking reference of range variable l or its field"
 		fmt.Println("addr: %v", &l.o) // want "taking reference of range variable l or its field"
 		for _, m := range lst {


### PR DESCRIPTION
A pointer deferenced nested field of a range variable is the same as the
nested field in the container element, so its ok to take its reference.
Modifications to such field are not modifying the copy but the actual
data in the container element.