### PR TITLE
golangci lint rule for unbalanced olog args

### DIFF
--- a/pkg/analyzer/olog_unbalanced_args.go
+++ b/pkg/analyzer/olog_unbalanced_args.go
@@ -1,0 +1,118 @@
+package analyzer
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+func init() {
+	registerAnalyzer(getOlogUnbalancedArgsAnalyzer())
+}
+
+// getOlogUnbalancedArgsAnalyzer builds and returns an Analyzer for the olog-unbalanced-args check.
+func getOlogUnbalancedArgsAnalyzer() *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name:     "ologUnbalancedArgs",
+		Doc:      "Checks that olog arguments are matched string/value pairs",
+		Run:      checkOlogUnbalancedArgs,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+	}
+}
+
+func isOlogCall(s *ast.CallExpr) bool {
+	if fn, is := s.Fun.(*ast.SelectorExpr); is {
+		if ident, is := fn.X.(*ast.Ident); is && ident.Name == "olog" {
+			// olog.Info/Error
+			if fn.Sel.Name == "Info" || fn.Sel.Name == "Error" {
+				// olog.Info/Error
+				return true
+			}
+		} else if call, is := fn.X.(*ast.CallExpr); is {
+			// olog.V(n).Info/Error
+			if sel, is := call.Fun.(*ast.SelectorExpr); is {
+				if x, is := sel.X.(*ast.Ident); is && x.Name == "olog" && sel.Sel.Name == "V" {
+					if fn.Sel.Name == "Info" || fn.Sel.Name == "Error" {
+						// olog.Info/Error
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func typeIsStringOrInterfaceArray(argt types.TypeAndValue) bool {
+	return false // TODO
+}
+
+func ologCallHasInvalidCount(s *ast.CallExpr, ti *types.Info) bool {
+	// first: It may be an unpack -- if so, allow it
+	if len(s.Args) == 2 {
+		if s.Ellipsis == token.NoPos {
+			// not an ellipsis unpack
+			return true
+		}
+		return false
+	}
+	if (len(s.Args) & 1) != 1 {
+		// not a string, key, value, key, value, ... matched set
+		return true
+	}
+	return false
+}
+
+func ologCallArgumentIsNotString(s *ast.CallExpr, ti *types.Info) bool {
+	if len(s.Args) < 3 {
+		// can't check when there's not args
+		return false
+	}
+	for i := 1; i < len(s.Args); i += 2 {
+		if typ, has := ti.Types[s.Args[i]]; has {
+			if bt, is := typ.Type.(*types.Basic); is {
+				if bt.Kind() != types.String {
+					// this is not a string! (retyped strings are OK)
+					return true
+				}
+			} else {
+				// this is not a string, because it's not a basic type
+				return true
+			}
+		}
+	}
+	// passed all checks, so no odd argument is not a string
+	return false
+}
+
+// checkOlogUnbalancedArgs checks if there's a call to an olog function that
+// requires string/value pairs, that doesn't get that.
+func checkOlogUnbalancedArgs(pass *analysis.Pass) (interface{}, error) {
+	visitor := func(node ast.Node) {
+		switch s := node.(type) {
+		case *ast.CallExpr:
+			if isOlogCall(s) {
+				if ologCallHasInvalidCount(s, pass.TypesInfo) {
+					pass.Reportf(s.Pos(), "olog key is missing value")
+				} else if ologCallArgumentIsNotString(s, pass.TypesInfo) {
+					pass.Reportf(s.Pos(), "olog key is not a string")
+				}
+			}
+		default:
+			// this shouldn't happen, the filter below shouldn't let this happen
+			panic(fmt.Sprintf("Unexpected statement of type %T received", s))
+		}
+	}
+
+	nodeFilter := []ast.Node{
+		(*ast.CallExpr)(nil),
+	}
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	insp.Preorder(nodeFilter, visitor)
+	return nil, nil
+}

--- a/pkg/analyzer/olog_unbalanced_args_test.go
+++ b/pkg/analyzer/olog_unbalanced_args_test.go
@@ -1,0 +1,17 @@
+package analyzer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestOlogUnbalancedArgs(t *testing.T) {
+	wd, err := os.Getwd()
+	require.Nil(t, err)
+	testdata := filepath.Join(wd, "testdata")
+	analysistest.Run(t, testdata, getOlogUnbalancedArgsAnalyzer(), "olog_unbalanced_args")
+}

--- a/pkg/analyzer/testdata/src/olog/olog.go
+++ b/pkg/analyzer/testdata/src/olog/olog.go
@@ -1,0 +1,38 @@
+// In real Observe code, we have a package called olog that requires balanced
+// key/value pairs of string,interface. To be able to write test code without
+// referencing observe code, dummy up the interface for that module here.
+package olog
+
+type Verbose bool
+
+func V(i int) Verbose {
+	return Verbose(i < 6)
+}
+
+//	This never gets called, but illustrates the requirement.
+func assertPairs(args []interface{}) {
+	if (len(args) & 1) != 0 {
+		panic("uneven pairs")
+	}
+	for i := 0; i != len(args); i++ {
+		if _, is := args[i].(string); !is {
+			panic("argument half should be string")
+		}
+	}
+}
+
+func (v Verbose) Info(msg string, args ...interface{}) {
+	assertPairs(args)
+}
+
+func (v Verbose) Error(msg string, args ...interface{}) {
+	assertPairs(args)
+}
+
+func Info(msg string, args ...interface{}) {
+	assertPairs(args)
+}
+
+func Error(msg string, args ...interface{}) {
+	assertPairs(args)
+}

--- a/pkg/analyzer/testdata/src/olog_unbalanced_args/basic.go
+++ b/pkg/analyzer/testdata/src/olog_unbalanced_args/basic.go
@@ -1,0 +1,36 @@
+package olog_unbalanced_args
+
+import "olog"
+
+func BasicFunc(n int) {
+	olog.Info("This is the message", "x", 3, "y", 5, "z")  // want "olog key is missing value"
+	olog.Info("This is the message", "x", 3, "y", 5)       // ok
+	olog.Error("This is the message", "x", 3, "y", 5, "z") // want "olog key is missing value"
+	olog.Error("This is the message", "x", 3, "y", 5)      // ok
+
+	// unpacks are OK; they are not type checked more than this
+	olog.Info("foo", []interface{}{"x", 3}...)
+	olog.Error("foo", []interface{}{"x", 3}...)
+
+	// note: not unpacked!
+	olog.Info("foo", []interface{}{"x", "y"})  // want "olog key is missing value"
+	olog.Error("foo", []interface{}{"x", "y"}) // want "olog key is missing value"
+
+	if olog.V(3) {
+		olog.Info("The message is here", 3, "x") // want "olog key is not a string"
+		olog.Info("The message is here", "x", 3) // ok
+	}
+	if olog.V(3) {
+		olog.Error("The message is here", 3, "x") // want "olog key is not a string"
+		olog.Error("The message is here", "z", 3) // ok
+	}
+
+	for j := 0; j != 2; j++ {
+		olog.V(j).Info("This is the message", "foo", j, "bar") // want "olog key is missing value"
+		olog.V(j).Info("This is the message", "foo", j)        // ok
+	}
+	for j := 0; j != 2; j++ {
+		olog.V(j).Error("This is the message", "foo", j, "bar") // want "olog key is missing value"
+		olog.V(j).Error("This is the message", "foo", j)        // ok
+	}
+}


### PR DESCRIPTION
olog info/error need every other arg to be a string (key name) and the
argument count to be even pairs of key/value, plus the initial message.